### PR TITLE
add options to enable/disable email sending  and maintenance

### DIFF
--- a/config.ps1
+++ b/config.ps1
@@ -7,12 +7,19 @@ $WindowsExcludeFile = Join-Path $InstallPath "windows.exclude"
 $LocalExcludeFile = Join-Path $InstallPath "local.exclude"
 $LogPath = Join-Path $InstallPath "logs"
 $LogRetentionDays = 30
+$InternetTestAttempts = 10
+$GlobalRetryAttempts = 4
+
+# maintenance configuration
+$SnapshotMaintenanceEnabled = $true
 $SnapshotRetentionPolicy = @("--keep-daily", "30", "--keep-weekly", "52", "--keep-monthly", "24", "--keep-yearly", "10")
 $SnapshotMaintenanceInterval = 7
 $SnapshotMaintenanceDays = 30
 $SnapshotDeepMaintenanceDays = 90;
-$InternetTestAttempts = 10
-$GlobalRetryAttempts = 4
+
+# email configuration
+$SendEmailOnSuccess = $false
+$SendEmailOnError = $true
 
 # Paths to backup
 $BackupSources = @{}


### PR DESCRIPTION
Users can now set the following variables to control sending emails on success and/or error conditions.
Users can now completely disable maintenance activities.

New `config.ps1` variable defaults for these options: 
```
$SnapshotMaintenanceEnabled = $true 
$SendEmailOnSuccess = $false
$SendEmailOnError = $true
```
Closes #2, Closes #3 