### PR TITLE
Add '-ExecutionPolicy Bypass' to the task scheduler arguments to avoi…

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -43,7 +43,7 @@ $backup_task_name = "Restic Backup"
 $backup_task = Get-ScheduledTask $backup_task_name -ErrorAction SilentlyContinue
 if($null -eq $backup_task) {
     try {
-        $task_action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '-NonInteractive -NoLogo -NoProfile -Command ".\backup.ps1; exit $LASTEXITCODE"' -WorkingDirectory $InstallPath
+        $task_action = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument '-ExecutionPolicy Bypass -NonInteractive -NoLogo -NoProfile -Command ".\backup.ps1; exit $LASTEXITCODE"' -WorkingDirectory $InstallPath
         $task_user = New-ScheduledTaskPrincipal -UserId "NT AUTHORITY\SYSTEM" -RunLevel Highest
         $task_settings = New-ScheduledTaskSettingsSet -RestartCount 4 -RestartInterval (New-TimeSpan -Minutes 15) -ExecutionTimeLimit (New-TimeSpan -Days 3) -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -DontStopOnIdleEnd -MultipleInstances IgnoreNew -IdleDuration 0 -IdleWaitTimeout 0 -StartWhenAvailable -RestartOnIdle
         $task_trigger = New-ScheduledTaskTrigger -Daily -At 4:00am


### PR DESCRIPTION
This should fix the issue described in https://github.com/kmwoley/restic-windows-backup/issues/27. Note that I haven't tested the installation script, I'm simply adding the argument that fixed the issue for me when I manually edited the task in task scheduler.