### PR TITLE
Update installer to install restic 0.12.0

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -5,10 +5,10 @@
 if(-not (Test-Path $ResticExe)) {
     $url = $null
     if([Environment]::Is64BitOperatingSystem){
-        $url = "https://github.com/restic/restic/releases/download/v0.9.6/restic_0.9.6_windows_amd64.zip"
+        $url = "https://github.com/restic/restic/releases/download/v0.12.0/restic_0.12.0_windows_amd64.zip"
     }
     else {
-        $url = "https://github.com/restic/restic/releases/download/v0.9.6/restic_0.9.6_windows_386.zip"
+        $url = "https://github.com/restic/restic/releases/download/v0.12.0/restic_0.12.0_windows_386.zip"
     }
     $output = Join-Path $InstallPath "restic.zip"
     Invoke-WebRequest -Uri $url -OutFile $output


### PR DESCRIPTION
This fixes the backup script's usage of features not available in the previous version.

Tested by me on Windows 10 Home with a rest server repo.