### PR TITLE
Handle spaces in paths

### DIFF
--- a/backup.ps1
+++ b/backup.ps1
@@ -140,7 +140,7 @@ function Invoke-Backup {
         # Build the new list of folders from settings (if there are any)
         $folder_list = New-Object System.Collections.Generic.List[System.Object]
         ForEach ($path in $item.Value) {
-            $p = Join-Path $root_path $path
+            $p = '"{0}"' -f ((Join-Path $root_path $path) -replace "\\$", "")
             $folder_list.Add($p)
         }
 


### PR DESCRIPTION
Adds double quotes around each path and removes a trailing backslash from them as well. I have found through experimentation that restic does not like a backslash followed by a double quote. The backslash appears to be an escape character.
Surrounding the path with double quotes allows paths with spaces to be used.