### PR TITLE
Add new no-scan option into default backup parameters

### DIFF
--- a/config.ps1
+++ b/config.ps1
@@ -10,7 +10,7 @@ $LogRetentionDays = 30
 $InternetTestAttempts = 10
 $GlobalRetryAttempts = 4
 $IgnoreMissingBackupSources = $false
-$AdditionalBackupParameters = @("--exclude-if-present", ".nobackup")
+$AdditionalBackupParameters = @("--exclude-if-present", "--no-scan", ".nobackup")
 
 # maintenance configuration
 $SnapshotMaintenanceEnabled = $true


### PR DESCRIPTION
As of the latest release of restic, version 0.15.0 a new backup option has been added: `--no-scan`. This disables the file tree scanning that is used to produce an ETA, speeding up the backup process.

As restic-windows-backup scripts are intended to be ran as recurring background tasks, would it not make sense to add this as a default option to the backup process?

Link: [Release Blog](https://restic.net/blog/2023-01-12/restic-0.15.0-released/)