### PR TITLE
Add check for domainpath as local repo

### DIFF
--- a/backup.ps1
+++ b/backup.ps1
@@ -355,7 +355,8 @@ function Invoke-ConnectivityCheck {
     }
 
     # skip the internet connectivity check for local repos
-    if(Test-Path $env:RESTIC_REPOSITORY) {
+    if((Test-Path $env:RESTIC_REPOSITORY) -or 
+        ($env:RESTIC_REPOSITORY -match "^\\\\\w")) {
         "[[Internet]] Local repository. Skipping internet connectivity check." | Out-File -Append $SuccessLog    
         return $true
     }


### PR DESCRIPTION
Domain paths (i.e. \\\server\share) for a repo are not recognized and consequently wrongly handled as an internet repo, making the backup script fail. The modification handles domain paths as a local repo.