### PR TITLE
Replace deprecated Send-MailMessage cmdlet with recommended Send-Mail…

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -1,6 +1,11 @@
 . .\config.ps1
 . .\secrets.ps1
 
+# install Mailkit module
+Register-PSRepository -Default -InstallationPolicy Trusted
+Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+Install-Module Send-MailKitMessage
+
 # download restic
 if(-not (Test-Path $ResticExe)) {
     $url = $null
@@ -59,5 +64,4 @@ if($null -eq $backup_task) {
 else {
     Write-Warning "[[Scheduler]] Backup task not scheduled: there is already a task with the name '$backup_task_name'."
 }
-
-
+    


### PR DESCRIPTION
Email functionality of backup.ps1 fails on Windows 11 23H2.  Send-MailMessage has been deprecated in favor of the Send-MailKitMessage module from PSGallery.

In this PR:

- install.ps1 has been changed to ensure that the Send-MailKitMessage module is installed
- The Send-Email function in backup.ps1 has been changed to use Send-MailKitMessage to send the email.

See issue 100 (Email sent from backup task fails on Windows 11)