### PR TITLE
Fix file list passing for powershell core v7.3+

### DIFF
--- a/backup.ps1
+++ b/backup.ps1
@@ -277,6 +277,9 @@ function Invoke-Backup {
             }
         }
         else {
+            # fix argument passing for pwsh v7.3+
+            $PSNativeCommandArgumentPassing = 'Legacy'
+            
             # Launch Restic
             & $ResticExe backup $folder_list $vss_option --tag "$tag" --exclude-file=$WindowsExcludeFile --exclude-file=$LocalExcludeFile $AdditionalBackupParameters 3>&1 2>> $ErrorLog | Out-File -Append $SuccessLog
             if(-not $?) {


### PR DESCRIPTION
v7.3 changed how quoted arguments are passed (see [stackoverflow explanation](https://stackoverflow.com/questions/74440303/powershell-7-3-0-breaking-command-invocation/74440425#74440425)). This change sets a var keep using the old method for compatibility.

The issue seems to revolve around line 245 where you add another set of quotes
```
$p = '"{0}"' -f ((Join-Path $root_path $path) -replace "\\$")
```
In my brief testing, even if you don't add the extra quotes, powershell v5 still works fine with paths with spaces, so I don't know what that change was for, but I'll let it stay for now.