### PR TITLE
Replace deprecated Send-MailMessage with Send-MailKitMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Simplifies the process of installation and running daily backups.
    1. Email sending configuration is also contained with this file. The scripts assume you want to get emails about the success/failure of each backup attempt.
 1. Run `install.ps1` file
    1. From the elevated (Run as Administrator) Powershell window, run `.\install.ps1`
-   1. This will initialize the repo, create your logfile directory, and create a scheduled task in Windows Task Scheduler to run the task daily.
+   1. This will initialize the repo, create your logfile directory, create a scheduled task in Windows Task Scheduler to run the task daily, and install Send-MailKitMessage module.
 1. Add your `$BackupSources` to `config.ps1`
    1. By default, all of `C:\` will be backed up. You can add multiple root drives to be backed up. And you can define only specific folders you would like backed up.
    1. External, removalbe disk drives (i.e. USB hard drives) can be identified by their Volume Label, Serial Number, or Device Name. For example, if you have an external device with the Volume Label "MY BOOK", you can define a backup source as `$BackupSources["MY BOOK"]=@()`. I would recommend using the device serial number to identify external drives to backup, which you can find using the Powershell `get-disk` command. You may also want to set `$IgnoreMissingBackupSources=$true` to avoid seeing errors when the removable drive is not present.

--- a/backup.ps1
+++ b/backup.ps1
@@ -297,6 +297,8 @@ function Invoke-Backup {
 function Send-Email {
     Param($SuccessLog, $ErrorLog, $Action)
 
+    Import-Module Send-MailKitMessage
+
     # default the action string to "Backup"
     if($null -eq $Action) {
         $Action = "Backup"
@@ -323,9 +325,9 @@ function Send-Email {
         $body = "Crtical Error! Restic $Action log is empty or missing. Check log file path."
         $status = "ERROR"
     }
-    $attachments = @{}
+    $attachments = [System.Collections.Generic.List[string]]::new()
     if (($null -ne $ErrorLog) -and (Test-Path $ErrorLog) -and (Get-Item $ErrorLog).Length -gt 0) {
-        $attachments = @{Attachments = $ErrorLog}
+        $attachments.Add("$ErrorLog")
         $status = "ERROR"
     }
     if((($status -eq "SUCCESS") -and ($SendEmailOnSuccess -ne $false)) -or ((($status -eq "ERROR") -or $past_failure) -and ($SendEmailOnError -ne $false))) {
@@ -334,7 +336,7 @@ function Send-Email {
         # create a temporary error log to log errors; can't write to the same file that Send-MailMessage is reading
         $temp_error_log = $ErrorLog + "_temp"
 
-        Send-MailMessage @ResticEmailConfig -From $ResticEmailFrom -To $ResticEmailTo -Credential $credentials -Subject $subject -Body $body @attachments 3>&1 2>> $temp_error_log
+        Send-MailKitMessage -SMTPServer $PSEmailServer -Port $PSEmailPort -UseSecureConnectionIfAvailable -Credential $credentials -From $ResticEmailFrom -RecipientList $ResticEmailTo -Subject $subject -TextBody $body -AttachmentList $attachments 3>&1 2>> $temp_error_log 
 
         if(-not $?) {
             "[[Email]] Sending email completed with errors" | Tee-Object -Append $temp_error_log | Out-File -Append $SuccessLog

--- a/install.ps1
+++ b/install.ps1
@@ -60,4 +60,5 @@ else {
     Write-Warning "[[Scheduler]] Backup task not scheduled: there is already a task with the name '$backup_task_name'."
 }
 
-
+# Install Send-MailKitMessage module
+Install-Module Send-MailKitMessage -Repository PSGallery -Scope AllUsers

--- a/secrets_template.ps1
+++ b/secrets_template.ps1
@@ -10,7 +10,7 @@ $Env:RESTIC_PASSWORD='<BACKUP PASSWORD>'
 
 # email configuration
 $PSEmailServer='<SMTP SERVER>'
-$ResticEmailConfig=@{UseSsl=$true; Port="587"}
+$PSEmailPort=25
 $ResticEmailTo='<DESTINATION EMAIL ADDRESS>'
 $ResticEmailFrom='<FROM EMAIL ADDRESS>'
 $ResticEmailUsername='<EMAIL LOGIN USERNAME>'


### PR DESCRIPTION
The Send-MailMessage cmdlet is obsolete. It doesn't guarantee secure connections to SMTP servers. This PR replaces it with Send-MailKitMessage module.

This PR is similar to https://github.com/kmwoley/restic-windows-backup/pull/101 but it is more refined in the sense that it supports port configuration, secure connection, attachments as the original implementation and maintains the existing variables that don't need changing.

