### PR TITLE
Add feature to control backups on metered connections

### DIFF
--- a/config.ps1
+++ b/config.ps1
@@ -7,6 +7,7 @@ $WindowsExcludeFile = Join-Path $InstallPath "windows.exclude"
 $LocalExcludeFile = Join-Path $InstallPath "local.exclude"
 $LogPath = Join-Path $InstallPath "logs"
 $LogRetentionDays = 30
+$BackupOnMeteredNetwork = $false
 $InternetTestAttempts = 10
 $GlobalRetryAttempts = 4
 $IgnoreMissingBackupSources = $false


### PR DESCRIPTION
`restic-windows-backup` runs backups irrespective of the host being on a metered connection or unrestricted. That can lead to situations in which the backup takes place when the user is on a metered connection and would rather not do it at that time, either because they would incur costs or use up their data allowance.

While the diff may seem to introduce many changes in `Invoke-Main`, it's actually a handful of lines for the `if` and `else` and the rest is purely changes to indentation of the existing code.

The default value of $BackupOnMeteredNetwork is set to `$false` following a conservative approach. It could also be set to `$true` to mirror what's currently happening.

Closes https://github.com/kmwoley/restic-windows-backup/issues/82