### PR TITLE
Add $AutoUnlock toggle to handle repository collisions

### DIFF
--- a/backup.ps1
+++ b/backup.ps1
@@ -101,14 +101,24 @@ function Invoke-Unlock {
         "[[Unlock]] Warning: unable to list locks." | Tee-Object -Append $ErrorLog
     }
     if($locks.Length -gt 0) {
-        # unlock the repository (assumes this machine is the only one that will ever use it)
-        Invoke-Expression "$Script:ResticExe unlock 3>&1 2>> $ErrorLog | Out-File -Append $SuccessLog"
-        if($LASTEXITCODE) {
-            "[[Unlock]] Error - unable to unlock repository." | Tee-Object -Append $ErrorLog
+        # check if we are allowed to unlock
+        if ($AutoUnlock -ne $false) {
+            # unlock the repository (assumes this machine is the only one that will ever use it)
+            Invoke-Expression "$Script:ResticExe unlock 3>&1 2>> $ErrorLog | Out-File -Append $SuccessLog"
+            if($LASTEXITCODE) {
+                "[[Unlock]] Error - unable to unlock repository." | Tee-Object -Append $ErrorLog
+                return $false
+            }
+            "[[Unlock]] Repository was locked. Unlocking." | Tee-Object -Append $ErrorLog | Out-File -Append $SuccessLog
+            Start-Sleep 120
+            return $true
         }
-        "[[Unlock]] Repository was locked. Unlocking." | Tee-Object -Append $ErrorLog | Out-File -Append $SuccessLog
-        Start-Sleep 120
+        else {
+            "[[Unlock]] Repository is locked and AutoUnlock is false. Skipping attempt." | Tee-Object -Append $ErrorLog | Out-File -Append $SuccessLog
+            return $false
+        }
     }
+    return $true
 }
 
 # test if maintenance on the backup set is needed. Return $true if maintenance is needed
@@ -574,8 +584,17 @@ function Invoke-Main {
 
         $repository_available = Invoke-ConnectivityCheck $success_log $error_log
         if($repository_available -eq $true) {
-            Invoke-Unlock $success_log $error_log
-            $backup_success = Invoke-Backup $success_log $error_log
+            # check if we can proceed based on lock state
+            $unlocked = Invoke-Unlock $success_log $error_log
+            
+            if ($unlocked) {
+                $backup_success = Invoke-Backup $success_log $error_log
+            }
+            else {
+                # if locked and we can't auto-unlock, treat this attempt as a failure
+                $backup_success = $false
+                "[[Backup]] Aborting attempt: Repository is locked." | Tee-Object -Append $success_log | Out-File -Append $error_log
+            }
 
             # NOTE: a previously locked repository will cause errors in the log; but backup would be 'successful'
             # Removing this overly-aggressive test for backup success and relying upon Invoke-Backup to report on success/failure
@@ -638,7 +657,16 @@ function Invoke-Main {
 
         $repository_available = Invoke-ConnectivityCheck $success_log $error_log
         if($repository_available -eq $true) {
-            $maintenance_success = Invoke-Maintenance $success_log $error_log
+            # check for locks during maintenance as well
+            $unlocked = Invoke-Unlock $success_log $error_log
+            
+            if ($unlocked) {
+                $maintenance_success = Invoke-Maintenance $success_log $error_log
+            }
+            else {
+                $maintenance_success = $false
+                "[[Maintenance]] Aborting attempt: Repository is locked." | Tee-Object -Append $success_log | Out-File -Append $error_log
+            }
 
             # $maintenance_success = ($maintenance_success -eq $true) -and (!(Test-Path $error_log) -or ((Get-Item $error_log).Length -eq 0))
             $total_attempts = $GlobalRetryAttempts - $attempt_count + 1

--- a/config_sample.ps1
+++ b/config_sample.ps1
@@ -10,6 +10,7 @@ $LogRetentionDays = 30
 $BackupOnMeteredNetwork = $true
 $InternetTestAttempts = 10
 $GlobalRetryAttempts = 4
+$AutoUnlock = $true
 
 # email configuration
 $SendEmailOnSuccess = $false


### PR DESCRIPTION
This PR introduces a new configuration toggle, `$AutoUnlock,` to give users control over how the script handles locked repositories.

By default, the script attempts to force an `unlock` whenever a lock is detected. While convenient for single-machine set-ups, this poses risks in multi-client environments. An automated unlock can inadvertently "break" a lock held by another active process, such as a concurrent backup from another workstation or a long-running prune or check operation, which can potentially lead to command failures or log errors.

This change allows users to opt-out of the automatic unlock behaviour by setting `$AutoUnlock = $false`. In this mode, the script will detect a lock and yield instead of forcing an unlock, utilizing the existing wait-and-retry logic to wait for the repository to become available. If the repository remains locked after all retry attempts, the script will exit without forcing an unlock.

**Notes**

- Backwards Compatibility: the logic defaults to the original auto-unlock behaviour if the variable is missing or null.
- Consistency: lock detection is integrated into both the backup and maintenance loops.
- Refactored Invoke-Unlock: the function now returns a boolean, allowing the main loop to gracefully enter the retry cycle if the repository is busy.