### PR TITLE
Replace plain-text secrets with DPAPI-encrypted vault

### DIFF
--- a/VaultManager.ps1
+++ b/VaultManager.ps1
@@ -1,0 +1,192 @@
+<#
+.SYNOPSIS
+    Manages secure restic credential vaults for the SYSTEM account.
+
+.DESCRIPTION
+    Creates a DPAPI-encrypted vault file that only the NT AUTHORITY\SYSTEM 
+    account can decrypt. This replaces plain-text secrets with secure 
+    identity-bound storage.
+    Requires an ELEVATED PowerShell session (Run as Administrator).
+
+.EXAMPLE
+    .\VaultManager.ps1 (Standalone creation flow)
+    . .\VaultManager.ps1; Export-VaultToEnv (Orchestration/Usage)
+#>
+
+param (
+    [Parameter(HelpMessage="Enter the filename or path for the vault.")]
+    [string]$VaultFile = "secrets.vault"
+)
+
+# Fast-fail if not Administrator
+if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Error "[[Vault]] This script must be run as an Administrator."
+    if ($MyInvocation.InvocationName -eq '.') { return } else { exit 1 }
+}
+
+function New-ResticVault {
+    <#
+    .SYNOPSIS
+        Collects restic secrets and triggers a SYSTEM task to encrypt them into a vault.
+    #>
+    param (
+        [string]$VaultFile = (Join-Path $PSScriptRoot "secrets.vault")
+    )
+
+    $VaultFile = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($VaultFile)
+
+    $VaultData = @{}
+    Write-Host "[[Vault]] Creating secure vault for SYSTEM..."
+
+    # restic repo password (mandatory)
+    $PasswordsMatch = $false
+    while (-not $PasswordsMatch) {
+        $PasswordInput = Read-Host "Enter restic repository password" -AsSecureString
+        if ($null -eq $PasswordInput) { 
+            Write-Host "[[Error]] Restic Password is required." -ForegroundColor Yellow
+            continue 
+        }
+
+        $ConfirmInput = Read-Host "Confirm restic repository password" -AsSecureString
+
+        # Unwrap to compare
+        $Ptr1 = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($PasswordInput)
+        $Ptr2 = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($ConfirmInput)
+        try {
+            $Plain1 = [Runtime.InteropServices.Marshal]::PtrToStringAuto($Ptr1)
+            $Plain2 = [Runtime.InteropServices.Marshal]::PtrToStringAuto($Ptr2)
+
+            if ($Plain1 -eq $Plain2) {
+                $VaultData["RESTIC_PASSWORD"] = $Plain1
+                $PasswordsMatch = $true
+            } else {
+                Write-Host "[[Error]] Passwords do not match. Please try again." -ForegroundColor Yellow
+            }
+        } finally {
+            [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($Ptr1)
+            [Runtime.InteropServices.Marshal]::ZeroFreeBSTR($Ptr2)
+        }
+    }
+
+    # Email password (optional)
+    $EmailPassInput = Read-Host "Enter Email/SMTP Password (Optional - Press Enter to skip)" -AsSecureString
+    if ($EmailPassInput -and $EmailPassInput.Length -gt 0) {
+        $BSTR = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($EmailPassInput)
+        $VaultData["RESTIC_EMAIL_PASSWORD"] = [Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+    }
+
+    # Other restic environment variable-secret pairs (optional)
+    Write-Host "Add other variables (e.g. AWS_ACCESS_KEY_ID, AZURE_ACCOUNT_KEY, etc.)"
+    while ($true) {
+        $VarName = Read-Host "Variable Name [Press Enter to finish]"
+        if ([string]::IsNullOrWhiteSpace($VarName)) { break }
+
+        $VarSecret = Read-Host "Value for $VarName" -AsSecureString
+        $BSTR = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($VarSecret)
+        $VaultData[$VarName] = [Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+    }
+
+    # Save a TEMPORARY plain-text transfer file
+    $TempTransferFile = Join-Path $env:TEMP "vault_transfer.tmp"
+    $VaultData | Export-Clixml -Path $TempTransferFile
+
+    # Define the SYSTEM bridge command with a safety finally block
+    $BridgeScript = Join-Path $env:TEMP "vault_bridge.ps1"
+    [System.IO.File]::WriteAllText($BridgeScript, @"
+try {
+    `$Data = Import-Clixml -Path '$TempTransferFile'
+    `$EncryptedData = @{}
+    foreach(`$Key in `$Data.Keys) { 
+        `$EncryptedData[`$Key] = `$Data[`$Key] | ConvertTo-SecureString -AsPlainText -Force 
+    }
+    `$EncryptedData | Export-Clixml -Path '$VaultFile'
+} finally {
+    if (Test-Path '$TempTransferFile') { Remove-Item '$TempTransferFile' -Force }
+}
+"@)
+
+    # Execute via Scheduled Task with user-side cleanup safety
+    try {
+        $TaskName = "ResticVaultSync"
+        $TaskArgs = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -File `"$BridgeScript`""
+        $TaskAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument $TaskArgs
+
+        Write-Host "[[Vault]] Elevating to SYSTEM to lock the vault..." -ForegroundColor Gray
+        Register-ScheduledTask -TaskName $TaskName -Action $TaskAction -User "NT AUTHORITY\SYSTEM" -RunLevel Highest | Out-Null
+        Start-ScheduledTask -TaskName $TaskName | Out-Null
+
+        # Wait for the file to appear
+        $Timeout = 0
+        while (-not (Test-Path $VaultFile) -and $Timeout++ -lt 15) { Start-Sleep 1 }
+    }
+    finally {
+        # Cleanup task and temp file if they still exist
+        Unregister-ScheduledTask -TaskName "ResticVaultSync" -Confirm:$false -ErrorAction SilentlyContinue
+        if (Test-Path $TempTransferFile) { Remove-Item $TempTransferFile -Force -ErrorAction SilentlyContinue }
+        if (Test-Path $BridgeScript) { Remove-Item $BridgeScript -Force -ErrorAction SilentlyContinue }
+    }
+
+    if (Test-Path $VaultFile) {
+        Write-Host "[[Vault]] Success: Vault created and locked to SYSTEM account."
+    } else {
+        Write-Error "[[Vault]] Vault creation failed. Check Scheduled Task logs."
+    }
+}
+
+function Export-VaultToEnv {
+    <#
+    .SYNOPSIS
+        Loads vault secrets into the current process environment.
+        Must be run by the account that encrypted the vault.
+    #>
+    param (
+        [string]$VaultFile = (Join-Path $PSScriptRoot "secrets.vault")
+    )
+
+    $VaultFile = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($VaultFile)
+    
+    if (-not (Test-Path $VaultFile)) { return $null }
+
+    $Vault = Import-Clixml -Path $VaultFile
+    $SecretMap = @{}
+
+    foreach ($Key in $Vault.Keys) {
+        $BSTR = [Runtime.InteropServices.Marshal]::SecureStringToBSTR($Vault[$Key])
+        $PlainValue = [Runtime.InteropServices.Marshal]::PtrToStringAuto($BSTR)
+
+        Set-Content -Path "Env:\$Key" -Value $PlainValue
+        $SecretMap[$Key] = $PlainValue
+    }
+    return $SecretMap
+}
+
+$IsStandalone = ($MyInvocation.InvocationName -ne '.') -and ($MyInvocation.Line -ne $null)
+
+if ($IsStandalone) {
+    # Path resolution
+    $FullVaultPath = if ([System.IO.Path]::IsPathRooted($VaultFile)) { 
+        $VaultFile 
+    } else { 
+        Join-Path $PSScriptRoot $VaultFile 
+    }
+
+    # Check for existing vault and backup
+    if (Test-Path $FullVaultPath) {
+        $Timestamp = Get-Date -Format "yyyyMMddTHHmmssffff"
+        $LeafName = Split-Path $FullVaultPath -Leaf
+        $BackupName = "$LeafName.$Timestamp.bak"
+        
+        Write-Host "[[Warning]] Vault file exists at: $FullVaultPath" -ForegroundColor Yellow
+        Write-Host "[[Vault]] Backing up existing vault to: $BackupName"
+        
+        try {
+            Rename-Item -Path $FullVaultPath -NewName $BackupName -Force -ErrorAction Stop
+        } catch {
+            Write-Error "[[Error]] Failed to backup existing vault. Aborting."
+            return
+        }
+    }
+
+    # Run the interactive creation flow
+    New-ResticVault -VaultFile $FullVaultPath
+}

--- a/backup.ps1
+++ b/backup.ps1
@@ -4,10 +4,12 @@
 
 # =========== start configuration =========== #
 
-# load restic configuration parameters (destination, passwords, etc.)
-$SecretsScript = Join-Path $PSScriptRoot "secrets.ps1"
+# load restic environment variables with credentials
+$VaultFile = Join-Path $PSScriptRoot "secrets.vault"  # New
+$SecretsScript = Join-Path $PSScriptRoot "secrets.ps1"  # Legacy
+$VaultManagerPath = Join-Path $PSScriptRoot "VaultManager.ps1"
 
-# load backup configuration variables
+# load configuration variables
 $ConfigScript = Join-Path $PSScriptRoot "config.ps1"
 
 # =========== end configuration =========== #
@@ -534,7 +536,22 @@ function Invoke-Main {
     }
 
     # initialize secrets
-    . $SecretsScript
+    if ((Test-Path $VaultFile) -and (Test-Path $VaultManagerPath)) {
+        # use secure vault if available
+        . $VaultManagerPath
+        $VaultData = Export-VaultToEnv -VaultFile $VaultFile
+
+        if ($null -ne $VaultData) {
+            # map the specific email password key
+            if ($VaultData.ContainsKey("RESTIC_EMAIL_PASSWORD")) {
+                $Script:ResticEmailPassword = $VaultData["RESTIC_EMAIL_PASSWORD"]
+            }
+        }
+    }
+    elseif (Test-Path $SecretsScript) {
+        # fallback to legacy plain-text script if vault is missing
+        . $SecretsScript
+    }
 
     # initialize config
     . $ConfigScript

--- a/config_sample.ps1
+++ b/config_sample.ps1
@@ -12,10 +12,16 @@ $InternetTestAttempts = 10
 $GlobalRetryAttempts = 4
 
 # email configuration
+$ResticEmailServer='<SMTP SERVER>'
+$ResticEmailPort='<SMTP PORT NUMBER, i.e. 25 or 587>'
+$ResticEmailTo='<DESTINATION EMAIL ADDRESS>'
+$ResticEmailFrom='<FROM EMAIL ADDRESS>'
+$ResticEmailUsername='<EMAIL LOGIN USERNAME OR EMPTY FOR NO USERNAME>'
 $SendEmailOnSuccess = $false
 $SendEmailOnError = $true
 
 # backup configuration
+$Env:RESTIC_REPOSITORY='<REPO URL>'
 $WindowsExcludeFile = Join-Path $InstallPath "windows.exclude"
 $LocalExcludeFile = Join-Path $InstallPath "local.exclude"
 $IgnoreMissingBackupSources = $false

--- a/install.ps1
+++ b/install.ps1
@@ -4,17 +4,25 @@
 
 # =========== start configuration =========== #
 
-# load restic configuration parmeters (destination, passwords, etc.)
-$SecretsScript = Join-Path $PSScriptRoot "secrets.ps1"
+# load restic environment variables with credentials
+$VaultFile = Join-Path $PSScriptRoot "secrets.vault"  # New
+$SecretsScript = Join-Path $PSScriptRoot "secrets.ps1"  # Legacy
+$VaultManagerPath = Join-Path $PSScriptRoot "VaultManager.ps1"
 
-# load backup configuration variables
+# load configuration variables
 $ConfigScript = Join-Path $PSScriptRoot "config.ps1"
 
-# initialize secrets
-. $SecretsScript
+# initialize secrets if the file exists
+if (Test-Path $SecretsScript) { . $SecretsScript }
 
 # initialize config
-. $ConfigScript
+if (Test-Path $ConfigScript) { 
+    . $ConfigScript 
+}
+else {
+    Write-Error "[[Error]] config.ps1 not found. Please create it from the template before running install."
+    exit 1
+}
 
 # apply global configuration
 $ResticExe = Join-Path $InstallPath $ExeName
@@ -22,6 +30,9 @@ $LogPath = Join-Path $InstallPath "logs"
 
 # make LASTEXITCODE global to enable error checking for Invoke-Expression commands
 $global:LASTEXITCODE=0
+
+# assume the repository is not initialized
+$RepoExists = $false
 
 # =========== end configuration =========== #
 
@@ -72,13 +83,115 @@ if(-not (Test-Path $LocalExcludeFile)) {
     New-Item -Type File -Path $LocalExcludeFile | Out-Null
 }
 
-# Initialize the restic repository
-Invoke-Expression "$ResticExe --verbose init"
-if($LASTEXITCODE) {
-    Write-Warning "[[Init]] Repository initialization failed. Check errors and resolve."
+# Setup secure credentials if they aren't already provided by secrets.ps1
+# Ask the repository question FIRST for everyone to set the $RepoExists state
+$RepoExists = (Read-Host "Is your restic repository already initialized? (Y/n)").ToLower() -ne 'n'
+# Handle the credentials
+if ([String]::IsNullOrEmpty($Env:RESTIC_PASSWORD)) {
+    if (-not (Test-Path $VaultFile)) {
+        if (Test-Path $VaultManagerPath) {
+            if (-not $RepoExists) {
+                Write-Host ("`n" + ("!" * 60)) -ForegroundColor Red 
+                Write-Host "                    IMPORTANT WARNING" -ForegroundColor Red 
+                Write-Host ("!" * 60) -ForegroundColor Red 
+                Write-Host " You are about to choose a password for the new repository." 
+                Write-Host " Remembering your password is important! If you lose it, you" 
+                Write-Host " won't be able to access data stored in the repository." 
+                Write-Host " Choose a STRONG password." 
+                Write-Host ("-" * 60) -ForegroundColor Red 
+            }
+            & {
+                # Create the vault
+                . $VaultManagerPath
+                New-ResticVault -VaultFile $VaultFile
+            }
+        } else {
+            Write-Error "[[Error]] VaultManager.ps1 not found. It is required to create a secure vault."
+            exit 1
+        }
+    } else {
+        # Situation: Vault file exists.
+        Write-Host "[[Vault]] Secure vault found. Using existing credentials."
+    }
+} else {
+    # Legacy path: They already have a password in secrets.ps1, so we just use it.
+    Write-Host "[[Secrets]] Legacy secrets.ps1 found. Using existing credentials."
 }
-else {
-    Write-Output "[[Init]] Repository successfully initialized."
+
+# Initialize the restic repository
+$ResticRepo = $Env:RESTIC_REPOSITORY
+$InitTask = "ResticRepoInit"
+$Timestamp = Get-Date -Format "yyyyMMddTHHmmssffff"
+$InitLog = Join-Path $LogPath "$Timestamp.init.log.txt"
+# Determine how to load secrets for the SYSTEM task
+if ((Test-Path $VaultFile) -and [String]::IsNullOrEmpty($Env:RESTIC_PASSWORD)) {
+    # Path A: use the secure vault
+    $SecretLoader = @"
+        . '$VaultManagerPath'
+        Export-VaultToEnv -VaultFile '$VaultFile'
+"@
+} elseif (-not [String]::IsNullOrEmpty($Env:RESTIC_PASSWORD)) {
+    # Path B: legacy secrets.ps1
+    $SecretLoader = if (Test-Path $SecretsScript) { ". '$SecretsScript'" } else { "" }
+} else {
+    Write-Error "[[Init]] Error: No credentials found. Please provide secrets.ps1 or secrets.vault."
+    exit 1
+}
+# Use the RepoExists flag set prior the vault / secrets logic
+$InitCmd = if ($RepoExists) { @("cat", "config") } else { @("init") }
+$InitScript = Join-Path $PSScriptRoot "init_script.ps1"
+[System.IO.File]::WriteAllText($InitScript, @"
+    try {
+        $SecretLoader
+        
+        `$resticArgs = @(
+            "-o", "sftp.args=-o BatchMode=yes",
+            $( ($InitCmd | ForEach-Object { "'$_'" }) -join ", "),
+            "-r", "$ResticRepo",
+            "--verbose"
+        )
+
+        & '$ResticExe' @resticArgs 2>&1 | Out-File -FilePath '$InitLog' -Encoding utf8
+    } 
+    finally {
+        # Capture the exit code of the last command (restic)
+        `$Code = if (`$null -eq `$LastExitCode) { 1 } else { `$LastExitCode }
+        # Explicitly terminate the session with that code
+        exit `$Code
+    }
+"@)
+if (Get-ScheduledTask -TaskName $InitTask -ErrorAction SilentlyContinue) {
+    Unregister-ScheduledTask -TaskName $InitTask -Confirm:$false
+}
+$InitArgs = "-ExecutionPolicy Bypass -NonInteractive -NoLogo -NoProfile -File `"$InitScript`""
+$InitAction = New-ScheduledTaskAction -Execute 'powershell.exe' -Argument $InitArgs
+Register-ScheduledTask -TaskName $InitTask -Action $InitAction -User "NT AUTHORITY\SYSTEM" | Out-Null
+try {
+    Start-ScheduledTask -TaskName $InitTask | Out-Null
+    $Timeout = 30; $Elapsed = 0
+    while ((Get-ScheduledTask -TaskName $InitTask).State -eq 'Running' -and $Elapsed++ -lt $Timeout) { Start-Sleep 1 }
+    if (Test-Path $InitLog) {
+        $RawOutput = Get-Content $InitLog -Raw
+        $InitResult = (Get-ScheduledTask -TaskName $InitTask | Get-ScheduledTaskInfo).LastTaskResult
+        # Successful creation (Exit 0)
+        $Success = ($InitResult -eq 0) 
+        # Already exists (Exit 1 + specific error string)
+        $AlreadyExists = ($InitResult -ne 0 -and $RawOutput -match "already exists")
+        # Verified existing (Exit 0 from 'cat config')
+        $Verified = ($InitResult -eq 0 -and $RawOutput -match "chunker_polynomial")
+        if ($Success -or $AlreadyExists -or $Verified) {
+            Write-Host "[[Init]] Success: Repository is ready."
+        } else {
+            Write-Warning "[[Init]] Fatal Error. Restic reported (Exit Code: $InitResult):"
+            Write-Host $RawOutput.Trim() -ForegroundColor Yellow
+            exit 1
+        }
+    }
+}
+finally {
+    Unregister-ScheduledTask -TaskName $InitTask -Confirm:$false -ErrorAction SilentlyContinue
+    if (Test-Path $InitScript) { Remove-Item $InitScript -ErrorAction SilentlyContinue }
+    Write-Host "[[Init]] Notice: Initialization log preserved at $InitLog"
 }
 
 # Scheduled Windows Task Scheduler to run the backup

--- a/secrets_sample.ps1
+++ b/secrets_sample.ps1
@@ -5,13 +5,7 @@
 # restic backup repository configuration
 $Env:AWS_ACCESS_KEY_ID='<KEY>'
 $Env:AWS_SECRET_ACCESS_KEY='<KEY>'
-$Env:RESTIC_REPOSITORY='<REPO URL>'
 $Env:RESTIC_PASSWORD='<BACKUP PASSWORD>'
 
 # email configuration
-$ResticEmailServer='<SMTP SERVER>'
-$ResticEmailPort='<SMTP PORT NUMBER, i.e. 25 or 587>'
-$ResticEmailTo='<DESTINATION EMAIL ADDRESS>'
-$ResticEmailFrom='<FROM EMAIL ADDRESS>'
-$ResticEmailUsername='<EMAIL LOGIN USERNAME OR EMPTY FOR NO USERNAME>'
 $ResticEmailPassword='<EMAIL PASSWORD OR EMPTY FOR NO PASSWORD>'


### PR DESCRIPTION
**Summary:** replaces the `secrets.ps1` file with a Windows Data Protection API (DPAPI) vault to prevent storing repository credentials in plain text.

**Changes:**

- **VaultManager.ps1**: a utility to create an encrypted **secrets.vault** file locked to the `SYSTEM` account.
- **System-Context Init**: moves repository initialization in `install.ps1` to a `SYSTEM` task to verify the account can unlock the vault and reach the repository before setup completes.
- **Credential retrieval**: updates `backup.ps1` to pull secrets from the vault, with a fallback for existing `secrets.ps1` files.
- **Config separation**: moves non-sensitive variables like Repository URL and SMTP settings to `config_sample.ps1`.

This PR supersedes https://github.com/kmwoley/restic-windows-backup/pull/113