### PR TITLE
Fix: install Send-MailKitMessage for PowerShell in pwsh

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -102,7 +102,16 @@ else {
 }
 
 # Install NuGet and Send-MailKitMessage module (by force)
-if ($PSVersionTable.PSVersion.Major -eq 5) {
-    Install-PackageProvider -Name NuGet -Force
+# For Windows PowerShell
+if (Get-Command powershell.exe -ErrorAction SilentlyContinue) {
+    powershell.exe -NoProfile -ExecutionPolicy Bypass -Command {
+        Install-PackageProvider -Name NuGet -Force > $null
+        Install-Module Send-MailKitMessage -Repository PSGallery -Scope AllUsers -Force
+    }
 }
-Install-Module Send-MailKitMessage -Repository PSGallery -Scope AllUsers -Force
+# For PowerShell
+if (Get-Command pwsh -ErrorAction SilentlyContinue) {
+    pwsh -NoProfile -ExecutionPolicy Bypass -Command {
+        Install-Module Send-MailKitMessage -Repository PSGallery -Scope AllUsers -Force
+    }
+}


### PR DESCRIPTION
**Summary**: this fix addresses a bug where the `Send-MailKitMessage` module is not found by the scheduled backup task if the initial installation was performed using PowerShell Core (pwsh).

When a user runs `install.ps1` in `pwsh`, the required mail module is installed into the Core-specific module path. However, the backup task created by the installer is configured to run via `powershell.exe` (Windows PowerShell). Since these two environments maintain separate module scopes, the backup task fails to send email notifications because it cannot locate the module installed during the setup phase.

The installer now explicitly invokes both `powershell.exe` and `pwsh` to install the module in both environments. This ensures the dependency is present regardless of which shell is used for installation or if the task shell is manually changed at a later date to `pwsh` .