### PR TITLE
Decouple restic update from maintenance

### DIFF
--- a/backup.ps1
+++ b/backup.ps1
@@ -192,18 +192,6 @@ function Invoke-Maintenance {
         $maintenance_success = $false
     }
 
-    # Invoke restic self-update to check for a newer version
-    # This is enabled by default unless configuration disables self-update
-    if ([String]::IsNullOrEmpty($SelfUpdateEnabled) -or ($SelfUpdateEnabled -eq $true)) {
-        # check for updated restic version
-        "[[Maintenance]] Checking for new version of restic..." | Out-File -Append $SuccessLog
-        Invoke-Expression "$Script:ResticExe self-update 3>&1 2>> $ErrorLog | Out-File -Append $SuccessLog"
-        if($LASTEXITCODE) {
-            "[[Maintenance]] Self-update of restic.exe completed with errors" | Tee-Object -Append $ErrorLog | Out-File -Append $SuccessLog
-            $maintenance_success = $false
-        }
-    }
-
     "[[Maintenance]] End $(Get-Date)" | Tee-Object -Append $SuccessLog | Write-Host
 
     if($maintenance_success -eq $true) {
@@ -523,6 +511,29 @@ function Invoke-HistoryCheck {
     }
 }
 
+# Invoke restic self-update to check for a newer version
+# This is enabled by default unless configuration disables self-update
+function Invoke-ResticUpdate {
+    Param($SuccessLog, $ErrorLog)
+    
+    if ($SelfUpdateEnabled -eq $false) { 
+        return $true 
+    }
+    "[[Update]] Checking for new version of restic..." | Out-File -Append $SuccessLog
+    Invoke-Expression "$Script:ResticExe self-update 3>&1 2>> $ErrorLog | Out-File -Append $SuccessLog"
+    $lastError = $global:LASTEXITCODE
+
+    if ($lastError -eq 0) {
+        # Status 0 = Success (already up to date OR successfully updated)
+        return $true
+    }
+    else {
+        # Status != 0 = Failure (Network, Permissions, etc.)
+        "[[Update]] Error: Restic self-update failed with exit code $lastError" | Tee-Object -Append $ErrorLog | Out-File -Append $SuccessLog
+        return $false
+    }
+}
+
 # main function
 function Invoke-Main {
 
@@ -607,6 +618,20 @@ function Invoke-Main {
             }
             else {
                 "[[Backup]] Retry limit has been reached. No more attempts to backup will be made." | Tee-Object -Append $success_log | Write-Host
+            }
+        }
+
+        if ($backup_success -eq $true -or $attempt_count -eq 0) {
+
+            $update_result = Invoke-ResticUpdate $success_log $error_log
+
+            if ($backup_success -eq $true -and $update_result -eq $false) {
+                 # Backup was successful but updating restic failed
+                "[[Update]] Warning: Backup was successful, but Restic update failed." | Tee-Object -Append $success_log | Write-Host
+            }
+            elseif ($update_result -eq $false) {
+                # Backup already failed, and updating restic failed too
+                $backup_success = $false 
             }
         }
 


### PR DESCRIPTION
**Summary:** this PR refactors the `self-update` logic to ensure the `restic` binary is updated regardless of maintenance settings or schedules.

**Changes:**

- Decoupling: moved the `self-update` logic out of `Invoke-Maintenance`. Previously, users who disabled maintenance would never receive binary updates through the script.
- Execution flow: the update check now occurs during the backup phase. It is triggered once per execution (either after a successful backup or after the final retry attempt) to avoid redundant network calls during repository retries.

**Rationale:** decoupling repository maintenance from binary updates supports several non-niche use cases and ensures a more reliable update cadence:

- Server-side maintenance: users who handle pruning and checking server-side or using another host (and thus disable maintenance in settings) still need, or might want, binary updates.
- Bug fixes: when a binary is released to fix a specific bug, it should be installed as soon as it is available, rather than waiting for the next scheduled maintenance window.
- Security patches: critical security fixes should be applied ASAP, which is currently not possible if maintenance is disabled or scheduled infrequently.

**Closing comments:** the current implementation maintains the existing strategy of updating the binary at the end of the process. However, it may be worth considering a "check-first" approach. Running the update before the backup would ensure that if a new binary introduces a bug, the error log clearly shows the update immediately followed by the backup failure. This would make the root cause more obvious and allow users to revert the binary version sooner.